### PR TITLE
Enable incremental revalidation for localized blog page

### DIFF
--- a/app/[locale]/blog/page.tsx
+++ b/app/[locale]/blog/page.tsx
@@ -3,6 +3,8 @@ import Link from "next/link";
 import Header from "@/components/layout/header";
 import Footer from "@/components/layout/footer";
 
+export const revalidate = 60;
+
 interface BlogPost {
   slug: string;
   title: string;
@@ -16,7 +18,7 @@ interface BlogPost {
 async function getBlogPosts(locale: string): Promise<BlogPost[]> {
   const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'http://localhost:3000';
   const res = await fetch(`${baseUrl}/api/blog?locale=${locale}`, {
-    cache: 'no-store' // or 'force-cache' for static generation
+    next: { revalidate: 60 }
   });
   
   if (!res.ok) {


### PR DESCRIPTION
## Summary
- add a route-level `revalidate` export for the localized blog listing page
- switch the blog fetch to use a `next.revalidate` hint so the listing can be cached and refreshed periodically

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de445314b883249b6fc8a0654ee29d