### PR TITLE
Add static params generation for localized blog routes

### DIFF
--- a/app/[locale]/blog/[slug]/page.tsx
+++ b/app/[locale]/blog/[slug]/page.tsx
@@ -3,6 +3,8 @@ import { Metadata } from "next";
 import { notFound } from "next/navigation";
 import Header from "@/components/layout/header";
 import Footer from "@/components/layout/footer";
+import { routing } from "@/i18n/routing";
+import { getBlogPosts } from "@/app/api/blog/route";
 
 interface BlogPost {
   slug: string;
@@ -46,6 +48,17 @@ export async function generateMetadata({
     title: `${post.title} | Blog`,
     description: post.excerpt,
   };
+}
+
+export async function generateStaticParams() {
+  const entries = await Promise.all(
+    routing.locales.map(async (locale) => {
+      const posts = await getBlogPosts(locale);
+      return posts.map((post) => ({ locale, slug: post.slug }));
+    })
+  );
+
+  return entries.flat();
 }
 
 export default async function BlogPostPage({

--- a/app/[locale]/blog/page.tsx
+++ b/app/[locale]/blog/page.tsx
@@ -2,6 +2,7 @@ import { Metadata } from "next";
 import Link from "next/link";
 import Header from "@/components/layout/header";
 import Footer from "@/components/layout/footer";
+import { routing } from "@/i18n/routing";
 
 interface BlogPost {
   slug: string;
@@ -31,10 +32,14 @@ export const metadata: Metadata = {
   description: "Read my latest thoughts on web development, technology, and more.",
 };
 
-export default async function BlogPage({ 
-  params 
-}: { 
-  params: Promise<{ locale: string }> 
+export function generateStaticParams() {
+  return routing.locales.map((locale) => ({ locale }));
+}
+
+export default async function BlogPage({
+  params
+}: {
+  params: Promise<{ locale: string }>
 }) {
   const { locale } = await params;
   const posts = await getBlogPosts(locale);

--- a/app/api/blog/route.ts
+++ b/app/api/blog/route.ts
@@ -15,7 +15,7 @@ interface BlogPost {
 }
 
 // Function to read blog posts from public directory for a specific locale
-async function getBlogPosts(locale: string = "en"): Promise<BlogPost[]> {
+export async function getBlogPosts(locale: string = "en"): Promise<BlogPost[]> {
   const blogDir = path.join(process.cwd(), "public", "blog", locale, "posts");
   
   try {


### PR DESCRIPTION
## Summary
- export `generateStaticParams` in the localized blog index to pre-render each supported locale
- add slug-level static params generation by reusing the filesystem-backed blog post helper
- expose the blog post reader so page and API routes share the same data source

## Testing
- npm run build *(fails: Next.js cannot download the Inter font in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de445578508324872087bb4325c924